### PR TITLE
BidTimeout Event BugFix

### DIFF
--- a/modules/openxAnalyticsAdapter.js
+++ b/modules/openxAnalyticsAdapter.js
@@ -281,6 +281,7 @@ let openxAdapter = Object.assign(adapter({ urlParam, analyticsType }), {
       }
     }
     else if (eventType === bidTimeoutConst) {
+      let auctionId = info[0].auctionId
       // utils.logInfo('SA: Bid Timedout for', auctionId);
       pushEvent(eventType, info, auctionId);
     }


### PR DESCRIPTION
AuctionId path for BidTimeout is different compared to other events. Corrected auctionId path in BidTimeout event.

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ x] Bugfix

Before Fix:
![image](https://user-images.githubusercontent.com/50863120/77583544-44538580-6f07-11ea-9073-8b74390327e7.png)

After Fix:
![image](https://user-images.githubusercontent.com/50863120/77583614-64834480-6f07-11ea-803a-0f37d0ada6e4.png)
![image](https://user-images.githubusercontent.com/50863120/77583689-87adf400-6f07-11ea-88ff-5f7c99dcc3b3.png)

