### PR TITLE
Adding "Ad Position" dimension to the Schema

### DIFF
--- a/modules/openxAnalyticsAdapter.js
+++ b/modules/openxAnalyticsAdapter.js
@@ -726,11 +726,16 @@ function getAdPositionByElementId(elementId) {
       let bottom = Math.min(windowHeight, bounding.bottom);
       let top = Math.max(0, bounding.top);
 
-      let intersectionArea = (right - left) * (bottom - top);
+      let intersectionWidth = right - left;
+      let intersectionHeight = bottom - top;
+
+      let intersectionArea = (intersectionHeight > 0 && intersectionWidth > 0) ? (intersectionHeight * intersectionWidth) : 0;
       let adSlotArea = (bounding.right - bounding.left) * (bounding.bottom - bounding.top);
 
-      // Atleast 50% of intersection in window
-      adPosition = (intersectionArea * 2 >= adSlotArea) ? "ATF" : "BTF";
+      if(adSlotArea > 0) {
+        // Atleast 50% of intersection in window
+        adPosition = (intersectionArea * 2 >= adSlotArea) ? "ATF" : "BTF";
+      }
     }
   } else {
     utils.logWarn("OX: DOM element not for id " + elementId);


### PR DESCRIPTION
Below are the functionalities that are added to support "Ad Position" dimension.
- When ad loads (triggered by `slotOnLoad` event) we capture its position using its DOM element id (_slot.getSlotElementId()_ method) and save it.
- While sending the data to server(triggered by _auctionEnd_ timeout or all the slot load events), we attach the above saved "Ad Position "data to payload and then publish the data.

_adPosition_ will be part of _adUnits_ info list in _auctionEnd_ event.

Possible "Ad Position" values
1. ATF
2. BTF
3. <Empty>

Note: There are some changes from the previous code review as well.