### PR TITLE
PBID-450: rename hasUserData field to more descriptive userIdProviders

### DIFF
--- a/modules/openxAnalyticsAdapter.js
+++ b/modules/openxAnalyticsAdapter.js
@@ -1145,7 +1145,7 @@ function buildAuctionPayload(auction) {
     browser: detectBrowser(),
     testCode: analyticsConfig.testCode,
     // return an array of module name that have user data
-    hasUserData: buildHasUserDataPayload(userIds),
+    userIdProviders: buildUserIdProviders(userIds),
     adUnits: buildAdUnitsPayload(adUnitCodeToAdUnitMap),
   };
 
@@ -1213,7 +1213,7 @@ function buildAuctionPayload(auction) {
     });
   }
 
-  function buildHasUserDataPayload(userIds) {
+  function buildUserIdProviders(userIds) {
     return utils._map(userIds, (userId) => {
       return utils._map(userId, (id, module) => {
         return hasUserData(module, id) ? module : false

--- a/test/spec/modules/openxAnalyticsAdapter_spec.js
+++ b/test/spec/modules/openxAnalyticsAdapter_spec.js
@@ -941,7 +941,7 @@ describe('openx analytics adapter', function() {
       });
 
       it('should track the user ids', function () {
-        expect(auction.hasUserData).to.deep.equal(['bla_id', 'digitrustid', 'lipbid', 'tdid']);
+        expect(auction.userIdProviders).to.deep.equal(['bla_id', 'digitrustid', 'lipbid', 'tdid']);
       });
 
       it('should not have responded', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
