### PR TITLE
OpenX handle response with missing seatbid and no nbr

### DIFF
--- a/modules/openxOrtbBidAdapter.js
+++ b/modules/openxOrtbBidAdapter.js
@@ -275,7 +275,7 @@ function interpretOrtbResponse(resp, req) {
   }
 
   const respBody = resp.body;
-  if (!respBody || 'nbr' in respBody) {
+  if (!respBody || 'nbr' in respBody || !Array.isArray(respBody.seatbid)) {
     return [];
   }
 

--- a/test/spec/modules/openxOrtbBidAdapter_spec.js
+++ b/test/spec/modules/openxOrtbBidAdapter_spec.js
@@ -1019,6 +1019,37 @@ describe('OpenxRtbAdapter', function () {
       });
     });
 
+    context('when no seatbid in response', function () {
+      let bids;
+      beforeEach(function () {
+        bidRequestConfigs = [{
+          bidder: 'openx',
+          params: {
+            unit: '12345678',
+            delDomain: 'test-del-domain'
+          },
+          adUnitCode: 'adunit-code',
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250], [300, 600]],
+            },
+          },
+          bidId: 'test-bid-id',
+          bidderRequestId: 'test-bidder-request-id',
+          auctionId: 'test-auction-id'
+        }];
+
+        bidRequest = spec.buildRequests(bidRequestConfigs, {refererInfo: {}})[0];
+
+        bidResponse = {ext: {}, id: 'test-bid-id'};
+        bids = spec.interpretResponse({body: bidResponse}, bidRequest);
+      });
+
+      it('should not return any bids', function () {
+        expect(bids.length).to.equal(0);
+      });
+    });
+
     context('when there is no response', function () {
       let bids;
       beforeEach(function () {


### PR DESCRIPTION
I have seen an openrtb response from openx that lacks both seatbid and nbr (basically just ext and id) which causes our adapter to fail on seatbid.foreach and therefore dropping the fledge response as well.