### PR TITLE
Support for BidRequest.Device.sua using user agent client hints

### DIFF
--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -268,6 +268,11 @@ function buildCommonQueryParamsFromBids(bids, bidderRequest) {
     nocache: new Date().getTime()
   };
 
+  const userAgentClientHints = deepAccess(bidderRequest, 'ortb2.device.sua');
+  if (userAgentClientHints) {
+    defaultParams.sua = JSON.stringify(userAgentClientHints);
+  }
+
   const userDataSegments = buildFpdQueryParams('user.data', bidderRequest.ortb2);
   if (userDataSegments.length > 0) {
     defaultParams.sm = userDataSegments;

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1729,6 +1729,47 @@ describe('OpenxAdapter', function () {
           });
         });
       });
+      describe('with user agent client hints', function () {
+        it('should add json query param sua with BidRequest.device.sua if available', function () {
+          const bidderRequestWithUserAgentClientHints = { refererInfo: {},
+            ortb2: {
+              device: {
+                sua: {
+                  source: 2,
+                  platform: {
+                    brand: 'macOS',
+                    version: [ '12', '4', '0' ]
+                  },
+                  browsers: [
+                    {
+                      brand: 'Chromium',
+                      version: [ '106', '0', '5249', '119' ]
+                    },
+                    {
+                      brand: 'Google Chrome',
+                      version: [ '106', '0', '5249', '119' ]
+                    },
+                    {
+                      brand: 'Not;A=Brand',
+                      version: [ '99', '0', '0', '0' ]
+                    }],
+                  mobile: 0,
+                  model: 'Pro',
+                  bitness: '64',
+                  architecture: 'x86'
+                }
+              }
+            }};
+
+          let request = spec.buildRequests([bidRequest], bidderRequestWithUserAgentClientHints);
+          expect(request[0].data.sua).to.exist;
+          const payload = JSON.parse(request[0].data.sua);
+          expect(payload).to.deep.equal(bidderRequestWithUserAgentClientHints.ortb2.device.sua);
+          const bidderRequestWithoutUserAgentClientHints = {refererInfo: {}, ortb2: {}};
+          request = spec.buildRequests([bidRequest], bidderRequestWithoutUserAgentClientHints);
+          expect(request[0].data.sua).to.not.exist;
+        });
+      });
     });
   })
 

--- a/test/spec/modules/openxOrtbBidAdapter_spec.js
+++ b/test/spec/modules/openxOrtbBidAdapter_spec.js
@@ -573,6 +573,47 @@ describe('OpenxRtbAdapter', function () {
             });
           });
         });
+
+        describe('with user agent client hints', function () {
+          it('should add device.sua if available', function () {
+            const bidderRequestWithUserAgentClientHints = { refererInfo: {},
+              ortb2: {
+                device: {
+                  sua: {
+                    source: 2,
+                    platform: {
+                      brand: 'macOS',
+                      version: [ '12', '4', '0' ]
+                    },
+                    browsers: [
+                      {
+                        brand: 'Chromium',
+                        version: [ '106', '0', '5249', '119' ]
+                      },
+                      {
+                        brand: 'Google Chrome',
+                        version: [ '106', '0', '5249', '119' ]
+                      },
+                      {
+                        brand: 'Not;A=Brand',
+                        version: [ '99', '0', '0', '0' ]
+                      }],
+                    mobile: 0,
+                    model: 'Pro',
+                    bitness: '64',
+                    architecture: 'x86'
+                  }
+                }
+              }};
+
+            let request = spec.buildRequests(bidRequests, bidderRequestWithUserAgentClientHints);
+            expect(request[0].data.device.sua).to.exist;
+            expect(request[0].data.device.sua).to.deep.equal(bidderRequestWithUserAgentClientHints.ortb2.device.sua);
+            const bidderRequestWithoutUserAgentClientHints = {refererInfo: {}, ortb2: {}};
+            request = spec.buildRequests(bidRequests, bidderRequestWithoutUserAgentClientHints);
+            expect(request[0].data.device.sua).to.not.exist;
+          });
+        });
       });
 
       context('when there is a consent management framework', function () {


### PR DESCRIPTION
-  for openxBidAdapter I've created a new query json param `sua` with user agent client hints 

- in openxOrtbBidAdapter I've created a test and it works without any changes in the code, so I think that openRtb converter works for BidRequest.Device.sua now